### PR TITLE
Some extension

### DIFF
--- a/rfm69/configuration.py
+++ b/rfm69/configuration.py
@@ -38,6 +38,21 @@ class DataModulation(RegisterValue):
         self.modulation_type = self.TypeFSK
         self.modulation_shaping = 0b00
 
+        
+class AfcFei(RegisterValue):
+    REGISTER = Register.AFCFEI
+    FORMAT = [(False, 1), ('fei_done', 1), ('fei_start', 1), ('afc_done', 1),
+             ('afc_autoclear_on', 1), ('afc_auto_on', 1), ('afc_clear', 1), ('afc_start', 1)]
+             
+    def __init__(self):
+        self.fei_done = False
+        self.fei_start = False
+        self.afc_done = True
+        self.afc_autoclear_on = False
+        self.afc_auto_on = False
+        self.afc_clear = False
+        self.afc_start = False
+
 class RSSIConfig(RegisterValue):
     REGISTER = 0x23
     FORMAT = [(False, 6), ('rssi_done', 1), ('rssi_start', 1)]
@@ -204,7 +219,8 @@ class RFM69Configuration(object):
         self.ocp = RF.OCP_ON | RF.OCP_TRIM_95
         self.lna = RF.LNA_ZIN_200
         self.rx_bw = RF.RXBW_DCCFREQ_010 | RF.RXBW_MANT_24 | RF.RXBW_EXP_5
-        self.afc_fei = RF.AFCFEI_AFCAUTO_OFF | RF.AFCFEI_AFCAUTOCLEAR_OFF
+        self.rx_afc_bw = RF.RXBW_DCCFREQ_010 | RF.RXBW_MANT_24 | RF.RXBW_EXP_5
+        self.afc_fei = AfcFei()
 
         self.dio_mapping_1 = DioMapping1()
         self.dio_mapping_2 = DioMapping2()
@@ -252,7 +268,8 @@ class RFM69Configuration(object):
         regs[Register.OCP] = self.ocp
         regs[Register.LNA] = self.lna
         regs[Register.RXBW] = self.rx_bw
-        regs[Register.AFCFEI] = self.afc_fei
+        regs[Register.AFCBW] = self.rx_afc_bw
+        regs[Register.AFCFEI] = self.afc_fei.pack()
         regs[Register.DIOMAPPING1] = self.dio_mapping_1.pack()
         regs[Register.DIOMAPPING2] = self.dio_mapping_2.pack()
         regs[Register.RSSITHRESH] = self.rssi_threshold

--- a/rfm69/configuration.py
+++ b/rfm69/configuration.py
@@ -118,7 +118,30 @@ class DioMapping1(RegisterValue):
         self.dio2 = self.DIOMAPPING_00
         self.dio3 = self.DIOMAPPING_00
 
+class DioMapping2(RegisterValue):
+    REGISTER = 0x26
+    FORMAT = [('dio4', 2), ('dio5', 2), (False, 1), ('clkout', 3)]
+    
+    DIOMAPPING_00 = 0
+    DIOMAPPING_01 = 1
+    DIOMAPPING_10 = 2
+    DIOMAPPING_11 = 3
+    
+    CLKOUT_1 = 0
+    CLKOUT_2 = 1
+    CLKOUT_4 = 2
+    CLKOUT_8 = 3
+    CLKOUT_16 = 4
+    CLKOUT_32 = 5
+    CLKOUT_RC = 6
+    CLKOUT_OFF = 7
+    
+    def __init__(self):
+        self.dio4 = self.DIOMAPPING_00
+        self.dio5 = self.DIOMAPPING_00
+        self.clkout = self.CLKOUT_OFF
 
+        
 class RFM69Configuration(object):
     """ An object to hold to represent the configuration of the RFM69. There's quite a bit of it.
 
@@ -150,7 +173,7 @@ class RFM69Configuration(object):
         self.afc_fei = RF.AFCFEI_AFCAUTO_OFF | RF.AFCFEI_AFCAUTOCLEAR_OFF
 
         self.dio_mapping_1 = DioMapping1()
-        self.dio_mapping_2 = RF.DIOMAPPING2_CLKOUT_OFF
+        self.dio_mapping_2 = DioMapping2()
 
         self.rssi_threshold = 200
 
@@ -194,7 +217,7 @@ class RFM69Configuration(object):
         regs[Register.RXBW] = self.rx_bw
         regs[Register.AFCFEI] = self.afc_fei
         regs[Register.DIOMAPPING1] = self.dio_mapping_1.pack()
-        regs[Register.DIOMAPPING2] = self.dio_mapping_2
+        regs[Register.DIOMAPPING2] = self.dio_mapping_2.pack()
         regs[Register.RSSITHRESH] = self.rssi_threshold
         regs[Register.RXTIMEOUT1] = self.rx_timeout_1
         regs[Register.RXTIMEOUT2] = self.rx_timeout_2

--- a/rfm69/configuration.py
+++ b/rfm69/configuration.py
@@ -102,6 +102,22 @@ class Temperature1(RegisterValue):
         self.start = False
         self.running = False
 
+        
+class DioMapping1(RegisterValue):
+    REGISTER = 0x25
+    FORMAT = [('dio0', 2), ('dio1', 2), ('dio2', 2), ('dio3', 2)]
+	
+    DIOMAPPING_00 = 0
+    DIOMAPPING_01 = 1
+    DIOMAPPING_10 = 2
+    DIOMAPPING_11 = 3
+	
+    def __init__(self):
+        self.dio0 = self.DIOMAPPING_00
+        self.dio1 = self.DIOMAPPING_00
+        self.dio2 = self.DIOMAPPING_00
+        self.dio3 = self.DIOMAPPING_00
+
 
 class RFM69Configuration(object):
     """ An object to hold to represent the configuration of the RFM69. There's quite a bit of it.
@@ -133,7 +149,7 @@ class RFM69Configuration(object):
         self.rx_bw = RF.RXBW_DCCFREQ_010 | RF.RXBW_MANT_24 | RF.RXBW_EXP_5
         self.afc_fei = RF.AFCFEI_AFCAUTO_OFF | RF.AFCFEI_AFCAUTOCLEAR_OFF
 
-        self.dio_mapping_1 = RF.DIOMAPPING1_DIO0_01
+        self.dio_mapping_1 = DioMapping1()
         self.dio_mapping_2 = RF.DIOMAPPING2_CLKOUT_OFF
 
         self.rssi_threshold = 200
@@ -177,7 +193,7 @@ class RFM69Configuration(object):
         regs[Register.LNA] = self.lna
         regs[Register.RXBW] = self.rx_bw
         regs[Register.AFCFEI] = self.afc_fei
-        regs[Register.DIOMAPPING1] = self.dio_mapping_1
+        regs[Register.DIOMAPPING1] = self.dio_mapping_1.pack()
         regs[Register.DIOMAPPING2] = self.dio_mapping_2
         regs[Register.RSSITHRESH] = self.rssi_threshold
         regs[Register.RXTIMEOUT1] = self.rx_timeout_1

--- a/rfm69/constants.py
+++ b/rfm69/constants.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+class HW():
+    FXOSC = 32E6
+    FSTEP = FXOSC / (1<<19)
 
 class Register(Enum):
     FIFO          = 0x00

--- a/rfm69/register_area.py
+++ b/rfm69/register_area.py
@@ -1,0 +1,23 @@
+from collections import OrderedDict
+
+class RegisterArea(object):
+    """ Represents a setting spread over multiple consecutive registers
+        
+        To use:
+            - append values to VALUES in your derived __init__
+            - add a static BASEREGISTER variable set to base register of value
+    """
+    
+    def pack(self):
+        regs = OrderedDict()
+        for i, val in enumerate(self.VALUES):
+            regs[self.BASEREGISTER + i] = val
+        return regs
+        
+    def set_word(self, word):
+        """ Sets complete registerarea using word
+        """
+        for i in reversed(range(len(self.VALUES))):
+            self.VALUES[i] = word & 0xFF
+            word >>= 8
+        

--- a/rfm69/rfm69.py
+++ b/rfm69/rfm69.py
@@ -36,7 +36,7 @@ class RFM69(object):
     def __init__(self, reset_pin=None, dio0_pin=None, spi_bus=None, config=None, spi_device=0):
         """ Initialise the object and configure the receiver.
 
-            reset_pin  -- the GPIO pin number which is attached to the reset pin of the RFM69
+            reset_pin  -- the GPIO pin number which is attached to the reset pin of the RFM69, may remain None
             dio0_pin   -- the GPIO pin number which is attached to the DIO0 pin of the RFM69
             spi_bus    -- the SPI bus used by the RFM69
             config     -- an instance of `RFM69Configuration`
@@ -69,11 +69,12 @@ class RFM69(object):
     def reset(self):
         """ Reset the module, then check it's working. """
         self.log.debug("Initialising RFM...")
-        GPIO.setup(self.reset_pin, GPIO.OUT)
-        GPIO.output(self.reset_pin, 1)
-        sleep(0.05)
-        GPIO.setup(self.reset_pin, GPIO.IN)
-        sleep(0.05)
+        if self.reset_pin is not None:
+            GPIO.setup(self.reset_pin, GPIO.OUT)
+            GPIO.output(self.reset_pin, 1)
+            sleep(0.05)
+            GPIO.setup(self.reset_pin, GPIO.IN)
+            sleep(0.05)
         if (self.spi_read(Register.VERSION) != 0x24):
             raise RadioError("Failed to initialise RFM69")
 

--- a/rfm69/rfm69.py
+++ b/rfm69/rfm69.py
@@ -33,19 +33,21 @@ def wait_for(condition, timeout=5, check_time=0.005):
 
 class RFM69(object):
     """ Interface for the RFM69 series of radio modules. """
-    def __init__(self, reset_pin=None, dio0_pin=None, spi_channel=None, config=None):
+    def __init__(self, reset_pin=None, dio0_pin=None, spi_bus=None, config=None, spi_device=0):
         """ Initialise the object and configure the receiver.
 
-            reset_pin -- the GPIO pin number which is attached to the reset pin of the RFM69
-            dio0_pin  -- the GPIO pin number which is attached to the DIO0 pin of the RFM69
-            spi_channel -- the SPI channel used by the RFM69
-            config    -- an instance of `RFM69Configuration`
+            reset_pin  -- the GPIO pin number which is attached to the reset pin of the RFM69
+            dio0_pin   -- the GPIO pin number which is attached to the DIO0 pin of the RFM69
+            spi_bus    -- the SPI bus used by the RFM69
+            config     -- an instance of `RFM69Configuration`
+            spi_device -- the SPI device used by the RFM69
         """
         self.log = logging.getLogger(__name__)
         self.reset_pin = reset_pin
         self.dio0_pin = dio0_pin
-        self.spi_channel = spi_channel
+        self.spi_bus = spi_bus
         self.config = config
+        self.spi_device = spi_device
         self.rx_restarts = 0
         self.init_gpio()
         self.init_spi()
@@ -60,7 +62,7 @@ class RFM69(object):
 
     def init_spi(self):
         self.spi = spidev.SpiDev()
-        self.spi.open(self.spi_channel, 0)
+        self.spi.open(self.spi_bus, self.spi_device)
         self.spi.bits_per_word = 8
         self.spi.max_speed_hz = 50000
 


### PR DESCRIPTION
- Configobject for AfcFei register
- fetch FEI on packet reception
- register areas for freg, fdev, bitrate etc.
- add configuration object for Dio2Mapping
- support reception of different packet types. i. e. large, fixes, variable, unlimited
- reset pin optional; some hardware does not use reset pin
- configurable SPI device in order to use 2nd chip select on Raspberry PI
- more to come soon
